### PR TITLE
Add Slurm scripts for Expanse

### DIFF
--- a/parallel/mpj_examples/sdsc_expanse_mpj_express.slurm
+++ b/parallel/mpj_examples/sdsc_expanse_mpj_express.slurm
@@ -71,6 +71,12 @@ scontrol show hostnames $SLURM_NODELIST > $PBS_NODEFILE
 export MPJ_HOME=$MPJ_HOME
 export PATH=$PATH:$MPJ_HOME/bin
 
+# Load necessary modules for Expanse
+module load sdsc
+module load cpu/0.15.4
+module use /cm/shared/apps/spack/0.21.2/cpu/a/share/spack/lmod/linux-rocky8-x86_64/Core
+module load openjdk/17.0.8.1_1 
+
 t1=$(date +%s) # epoch start time in seconds                                       
 
 date                                                                               

--- a/parallel/mpj_examples/sdsc_expanse_mpj_express.slurm
+++ b/parallel/mpj_examples/sdsc_expanse_mpj_express.slurm
@@ -1,0 +1,89 @@
+#!/bin/bash
+
+#SBATCH --time 24:00:00
+#SBATCH --nodes 14
+#SBATCH --ntasks 14 --cpus-per-task=128                                                     
+#SBATCH --account=ddp408                                                           
+#SBATCH --constraint="lustre"                                                      
+#SBATCH --partition compute                                                        
+#SBATCH --mem 0
+
+######################
+## INPUT PARAMETERS ##
+######################
+
+# the above '#SBATCH' lines are requred, and are supposed to start with a '#'. They must be at the beginning of the file
+# the '--time hh:mm:ss' argument is the wall clock time of the job
+# the '--nodes 14' argument specifies the number of nodes required, in this case 14
+# the '--cpus-per-task=128' argument specifies that we need access to all 128 cores on each node
+# the '--partition compute' argument specifies the queue, this line can be removed if you want the default queue
+# the '--mem 0' argument specifies that we want access to all available memory on the compute nodes
+
+## ETAS PARAMETERS ##
+
+# path to the JSON configuration file
+ETAS_CONF_JSON=/path/to/etas_conf.json
+
+## JAVA/MPJ PARAMETERS ##
+
+# maxmimum memory in gigabytes. should be close to, but not over, total memory available
+MEM_GIGS=200
+
+# number of etas threads. should be approximately MEM_GIGS/5, and no more than the total number of threads available
+THREADS=40
+
+# MPJ_HOME directory.
+# You can also fetch this directory via Git by cloning https://github.com/kevinmilner/mpj-express.git
+MPJ_HOME=/expanse/lustre/projects/usc143/$USER/mpj-express                                 
+
+# path to the opensha-ucerf3 jar file
+JAR_FILE=${ETAS_LAUNCHER}/opensha/opensha-all.jar
+
+# simulations are sent out in batches to each compute node. these paramters control the size of those batches
+# smaller max size will allow for better checking of progress with watch_logparse.sh, but more wasted time at the end of batches waiting on a single calculation to finish
+MIN_DISPATCH=$THREADS
+MAX_DISPATCH=100
+
+# this allows for catalogs to be written locally on each compute node in a temporary directory, then only copied back onto shared storage after they complete. this reduces I/O load, but makes it harder to track progress of individual simulations. comment this out to disable this option
+TEMP_OPTION="--temp-dir $TMPDIR"
+
+# this allows for catalogs to be written to temporary scratch storage and symbolically linked back. only final consolidated binary files will be written to the primary output directory
+SCRATCH_OPTION="--scratch-dir /expanse/lustre/scratch/$USER/temp_project/etas_scratch"
+
+# this automatically deletes subdirectories of the results directory once a catalog has been sucessfully written to the master binary file. comment out to disable
+CLEAN_OPTION="--clean"
+
+##########################
+## END INPUT PARAMETERS ##
+##   DO NOT EDIT BELOW  ##
+##########################
+
+NEW_JAR="`dirname ${ETAS_CONF_JSON}`/`basename $JAR_FILE`"
+cp $JAR_FILE $NEW_JAR
+if [[ -e $NEW_JAR ]];then
+	JAR_FILE=$NEW_JAR
+fi
+
+PBS_NODEFILE="/tmp/${USER}-hostfile-${SLURM_JOBID}"
+echo "creating PBS_NODEFILE: $PBS_NODEFILE"
+scontrol show hostnames $SLURM_NODELIST > $PBS_NODEFILE
+
+export MPJ_HOME=$MPJ_HOME
+export PATH=$PATH:$MPJ_HOME/bin
+
+t1=$(date +%s) # epoch start time in seconds                                       
+
+date                                                                               
+echo "RUNNING MPJ"                                                                 
+mpjrun_errdetect_wrapper.sh $PBS_NODEFILE -dev hybdev -Djava.library.path=$MPJ_HOME/lib -Xmx${MEM_GIGS}G -cp $JAR_FILE scratch.UCERF3.erf.ETAS.launcher.MPJ_ETAS_Launcher --min-dispatch $MIN_DISPATCH --max-dispatch $MAX_DISPATCH --threads $THREADS $TEMP_OPTION $SCRATCH_OPTION $CLEAN_OPTION --end-time `scontrol show job $SLURM_JOB_ID | egrep --only
+-matching 'EndTime=[^ ]+' | cut -c 9-` $ETAS_CONF_JSON                          
+ret=$?                                                                             
+date
+
+t2=$(date +%s) # epoch end time in seconds                                         
+numSec=$(echo $t2 - $t1 | bc -q ) # the number of seconds the process took.        
+runTime=$(date -ud @$numSec +%T) # Convert the seconds into Hours:Mins:Sec      
+echo "Time to build: $runTime ($numSec seconds)"                                
+
+exit $ret
+

--- a/parallel/mpj_examples/sdsc_expanse_plot.slurm
+++ b/parallel/mpj_examples/sdsc_expanse_plot.slurm
@@ -1,0 +1,55 @@
+#!/bin/bash
+
+#SBATCH --time 3:00:00
+#SBATCH --nodes 1
+#SBATCH --ntasks=1 --cpus-per-task=128
+#SBATCH --account=usc143                                                           
+#SBATCH --partition compute
+#SBATCH --mem 0
+
+######################
+## INPUT PARAMETERS ##
+######################
+
+# the above '#SBATCH' lines are requred, and are supposed to start with a '#'. They must be at the beginning of the file
+# the '--time hh:mm:ss' argument is the wall clock time of the job
+# the '--nodes 1' argument specifies the number of nodes required, in this case 1
+# the '--partition compute' argument specifies the queue, this line can be removed if you want the default queue
+# the '--mem 0' argument fixes some HPC weirdness and shouldn't be removed
+
+## ETAS PARAMETERS ##
+
+# path to the JSON configuration file
+ETAS_CONF_JSON=/path/to/etas_config.json
+
+# path to ComCat catalog for ComCat comparison plots. this only applies to simulation configuration which include the ComCat metadata files, and where the compute nodes cannot reach the outside world (e.g. for USC HPC). If the compute node can see the outside world, you can leave this as blank (or comment out) and events will be fetched at runtime.
+# this file is generated with the 'u3etas_comcat_catalog_fetcher.sh <config.json>' command
+#COMCAT_CATALOG=/path/to/comcat-events.txt
+
+# no maps option - uncomment this to skip any map generation which requires access to a servlet on opensha.usc.edu. this option should be enabled if your compute nodes cannot reach the outside world, or if the opensha server is down or otherwise inaccessible
+#NO_MAPS_OPTION="--no-maps"
+
+# uncomment this if you want to force it to regenerate all plots on subsequent reruns of this script
+#FORCE_UPDATE_OPTION="--force-update"
+
+## JAVA PARAMETERS ##
+
+# maxmimum memory in gigabytes. should be close to, but not over, total memory available
+MEM_GIGS=220
+
+# number of processing threads to handle plots, can be up to 20
+THREADS=44
+
+# path to the opensha-ucerf3 jar file
+JAR_FILE=${ETAS_LAUNCHER}/opensha/opensha-all.jar
+
+##########################
+## END INPUT PARAMETERS ##
+##   DO NOT EDIT BELOW  ##
+##########################
+
+if [[ -e $COMCAT_CATALOG ]];then
+	COMCAT_OPTION="--comcat-catalog $COMCAT_CATALOG"
+fi
+
+java -Djava.awt.headless=true -Xmx${MEM_GIGS}G -cp $JAR_FILE scratch.UCERF3.erf.ETAS.analysis.SimulationMarkdownGenerator --threads $THREADS $NO_MAPS_OPTION $FORCE_UPDATE_OPTION $COMCAT_OPTION $ETAS_CONF_JSON


### PR DESCRIPTION
Adds an hpc-site default for building etas configurations on SDSC Expanse HPC.

A corresponding PR for OpenSHA ETAS_ConfigBuilder (https://github.com/opensha/opensha/pull/229) allows for updating SBATCH lines with long-form arguments. (e.g., --time and -t, --partition and -p).