### PR TITLE
Fix Expanse Slurm

### DIFF
--- a/parallel/mpj_examples/sdsc_expanse_mpj_express.slurm
+++ b/parallel/mpj_examples/sdsc_expanse_mpj_express.slurm
@@ -71,18 +71,11 @@ scontrol show hostnames $SLURM_NODELIST > $PBS_NODEFILE
 export MPJ_HOME=$MPJ_HOME
 export PATH=$PATH:$MPJ_HOME/bin
 
-# Load necessary modules for Expanse
-module load sdsc
-module load cpu/0.15.4
-module use /cm/shared/apps/spack/0.21.2/cpu/a/share/spack/lmod/linux-rocky8-x86_64/Core
-module load openjdk/17.0.8.1_1 
-
 t1=$(date +%s) # epoch start time in seconds                                       
 
 date                                                                               
 echo "RUNNING MPJ"                                                                 
-mpjrun_errdetect_wrapper.sh $PBS_NODEFILE -dev hybdev -Djava.library.path=$MPJ_HOME/lib -Xmx${MEM_GIGS}G -cp $JAR_FILE scratch.UCERF3.erf.ETAS.launcher.MPJ_ETAS_Launcher --min-dispatch $MIN_DISPATCH --max-dispatch $MAX_DISPATCH --threads $THREADS $TEMP_OPTION $SCRATCH_OPTION $CLEAN_OPTION --end-time `scontrol show job $SLURM_JOB_ID | egrep --only
--matching 'EndTime=[^ ]+' | cut -c 9-` $ETAS_CONF_JSON                          
+mpjrun_errdetect_wrapper.sh $PBS_NODEFILE -dev hybdev -Djava.library.path=$MPJ_HOME/lib -Xmx${MEM_GIGS}G -cp $JAR_FILE scratch.UCERF3.erf.ETAS.launcher.MPJ_ETAS_Launcher --min-dispatch $MIN_DISPATCH --max-dispatch $MAX_DISPATCH --threads $THREADS $TEMP_OPTION $SCRATCH_OPTION $CLEAN_OPTION --end-time `scontrol show job $SLURM_JOB_ID | egrep --only-matching 'EndTime=[^ ]+' | cut -c 9-` $ETAS_CONF_JSON                          
 ret=$?                                                                             
 date
 

--- a/parallel/mpj_examples/sdsc_expanse_plot.slurm
+++ b/parallel/mpj_examples/sdsc_expanse_plot.slurm
@@ -2,7 +2,8 @@
 
 #SBATCH --time 3:00:00
 #SBATCH --nodes 1
-#SBATCH --ntasks=1 --cpus-per-task=128
+#SBATCH --ntasks=1
+#SBATCH --cpus-per-task=128
 #SBATCH --account=usc143                                                           
 #SBATCH --partition compute
 #SBATCH --mem 0


### PR DESCRIPTION
- Modules shouldn't be loaded in the Slurm script, but are instead loaded in the ucerf3-etas-env-wrapper script.
- The MPJ Run command was broken previously.